### PR TITLE
feat: support platform & repository_url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "repo_manager_v2" ]
+  pull_request:
+    branches: [ "repo_manager_v2" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...
+
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag robot-gitee-repo-watcher:$(date +%s)

--- a/community/repos.go
+++ b/community/repos.go
@@ -79,6 +79,7 @@ type Repository struct {
 	Commentable       bool         `json:"commentable,omitempty"`
 	ProtectedBranches []string     `json:"protected_branches,omitempty"`
 	RepoUrl           string       `json:"repository_url"`
+	Platform          string       `json:"platform"`
 	Branches          []RepoBranch `json:"branches,omitempty"`
 
 	RepoMember

--- a/watch_test.go
+++ b/watch_test.go
@@ -1,73 +1,32 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/opensourceways/robot-gitee-repo-watcher/community"
 )
 
-func TestCanCreateRepoNoRepoUrl(t *testing.T) {
-	expect := expectRepoInfo{
-		org: "src-openeuler",
-		expectRepoState: &community.Repository{
-			Name: "i3",
-		},
+func TestCanProcess(t *testing.T) {
+	testCase := [][]string{
+		{"", "", "true"},
+		{"xxx", "", "false"},
+		{"xx", "github", "false"},
+		{"", "gitee", "true"},
+		{"", "github", "false"},
 	}
-	if !CanProcess(expect) {
-		t.Fail()
-	}
-}
 
-func TestCanCreateRepoWithRepoUrl(t *testing.T) {
-
-	expect := expectRepoInfo{
-		org: "src-openeuler",
-		expectRepoState: &community.Repository{
-			Name:    "i3",
-			RepoUrl: "https://gitee.com/src-openeuler/i3",
-		},
-	}
-	if !CanProcess(expect) {
-		t.Fail()
-	}
-}
-
-func TestCanCreateRepoWithGithubRepoUrl(t *testing.T) {
-	expect := expectRepoInfo{
-		org: "src-openeuler",
-		expectRepoState: &community.Repository{
-			Name:    "i3",
-			RepoUrl: "https://github.com/src-openeuler/i3",
-		},
-	}
-	if CanProcess(expect) {
-		t.Fail()
-	}
-}
-
-func TestCanCreateRepoWithInvalidRepoUrl(t *testing.T) {
-	expect := expectRepoInfo{
-		org: "src-openeuler",
-		expectRepoState: &community.Repository{
-			Name:    "i3",
-			RepoUrl: "src-openeuler/i3",
-		},
-	}
-	if CanProcess(expect) {
-		t.Fail()
-	}
-}
-
-func TestCanCreateRepoWithValidRepo(t *testing.T) {
-
-	expect := expectRepoInfo{
-		org: "src-openeuler",
-		expectRepoState: &community.Repository{
-			Name:    "i3",
-			RepoUrl: "gitee.com/openeuler/i3",
-		},
-	}
-	if CanProcess(expect) {
-		t.Fail()
+	for k, v := range testCase {
+		expect := expectRepoInfo{
+			org: "src-openeuler",
+			expectRepoState: &community.Repository{
+				Name:     "i3",
+				RepoUrl:  v[0],
+				Platform: v[1],
+			},
+		}
+		if strconv.FormatBool(CanProcess(expect)) != v[2] {
+			t.Errorf("case num %d failed", k)
+		}
 	}
 }


### PR DESCRIPTION
support platform & repository_url :
repository_url：用来控制ci bot是否建仓，用于支持社区直接引用其他的仓库，配置了该字段的仓库不需要创建代码仓库
platform（取值可以是gitee/github/gitlab）：用来控制原本的创仓逻辑发生在哪个托管平台，gitee机器人只处理未指定platform和值为gitee的场景

如果同时配置了两个参数，优先考虑repository_url
